### PR TITLE
Added Configuration for tree generation radius

### DIFF
--- a/src/main/java/org/labellum/mc/dynamictreestfc/DTFCGenerator.java
+++ b/src/main/java/org/labellum/mc/dynamictreestfc/DTFCGenerator.java
@@ -2,6 +2,7 @@ package org.labellum.mc.dynamictreestfc;
 
 import java.util.Random;
 
+import net.dries007.tfc.types.DefaultTrees;
 import net.minecraft.block.Block;
 
 import net.minecraft.block.state.IBlockState;
@@ -11,17 +12,13 @@ import net.minecraft.world.gen.structure.template.TemplateManager;
 
 
 import com.ferreusveritas.dynamictrees.blocks.BlockBranch;
-import com.ferreusveritas.dynamictrees.blocks.BlockDynamicLeaves;
 import com.ferreusveritas.dynamictrees.trees.Species;
 import com.ferreusveritas.dynamictrees.util.SafeChunkBounds;
 import net.dries007.tfc.api.types.Tree;
 import net.dries007.tfc.api.util.ITreeGenerator;
 import net.dries007.tfc.objects.blocks.BlocksTFC;
 import net.dries007.tfc.objects.blocks.wood.BlockSaplingTFC;
-import net.dries007.tfc.world.classic.chunkdata.ChunkDataProvider;
-import net.dries007.tfc.world.classic.chunkdata.ChunkDataTFC;
 import org.labellum.mc.dynamictreestfc.trees.TreeFamilyTFC;
-
 
 public class DTFCGenerator implements ITreeGenerator
 {
@@ -74,6 +71,15 @@ public class DTFCGenerator implements ITreeGenerator
         }
 
         dtRadius = radiusCoordinator.getRadiusAtCoords(pos.getX(),pos.getZ());
+
+        // Only checks to change radius of smaller trees
+        if (!treeType.isConifer()
+                && treeType.getMaxHeight() <= 16
+                && treeType.getRegistryName() != DefaultTrees.DOUGLAS_FIR
+        )
+        {
+             dtRadius *= DTTFCConfig.General.radiusMultiplier;
+        }
 
         //check on ground and nearby trees
         int x;

--- a/src/main/java/org/labellum/mc/dynamictreestfc/DTTFCConfig.java
+++ b/src/main/java/org/labellum/mc/dynamictreestfc/DTTFCConfig.java
@@ -1,0 +1,21 @@
+package org.labellum.mc.dynamictreestfc;
+
+import net.minecraftforge.common.config.Config;
+
+@Config(modid = DynamicTreesTFC.MOD_ID)
+@Config.LangKey("config." + DynamicTreesTFC.MOD_ID)
+public class DTTFCConfig
+{
+    @Config.RequiresWorldRestart
+    @Config.Comment("General settings")
+    @Config.LangKey("config." + DynamicTreesTFC.MOD_ID + ".general")
+    public static final GeneralCfg General = new GeneralCfg();
+
+    public static class GeneralCfg
+    {
+        @Config.Comment("Multiplier for tree radius.")
+        @Config.LangKey("config." + DynamicTreesTFC.MOD_ID + ".general.radiusMultiplier")
+        @Config.RangeDouble(min = 0.1, max = 1.0)
+        public double radiusMultiplier = 0.75;
+    }
+}


### PR DESCRIPTION
This allows players to config how dense forests are.

There is exactly one double config options that lets players choose a size multiplier for generated trees. This means that a smaller radius would lead to more trees being generated, allowing players to make their worlds more foresty.