### PR TITLE
Bake frond models with parent model instead of deferring

### DIFF
--- a/src/main/java/org/labellum/mc/dttfc/client/ClientModEvents.java
+++ b/src/main/java/org/labellum/mc/dttfc/client/ClientModEvents.java
@@ -9,18 +9,11 @@ public final class ClientModEvents
     public static void init()
     {
         final IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
-        bus.addListener(ClientModEvents::onModelBake);
         bus.addListener(ClientModEvents::onModelRegister);
     }
 
     public static void onModelRegister(ModelEvent.RegisterGeometryLoaders event)
     {
         event.register("palm_fronds", new PalmLeavesModelLoader());
-    }
-
-    public static void onModelBake(ModelEvent.BakingCompleted event)
-    {
-        // Setup fronds models
-        PalmLeavesBakedModel.INSTANCES.forEach(PalmLeavesBakedModel::setupModels);
     }
 }

--- a/src/main/java/org/labellum/mc/dttfc/client/PalmLeavesBakedModel.java
+++ b/src/main/java/org/labellum/mc/dttfc/client/PalmLeavesBakedModel.java
@@ -5,8 +5,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Function;
+
 import com.ferreusveritas.dynamictrees.block.leaves.PalmLeavesProperties;
-import com.ferreusveritas.dynamictrees.client.ModelUtils;
 import com.ferreusveritas.dynamictrees.util.CoordUtils;
 import com.google.common.primitives.Ints;
 import net.minecraft.client.renderer.RenderType;
@@ -15,8 +16,10 @@ import net.minecraft.client.renderer.block.model.BlockModel;
 import net.minecraft.client.renderer.block.model.FaceBakery;
 import net.minecraft.client.renderer.block.model.ItemOverrides;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.Material;
 import net.minecraft.client.resources.model.SimpleBakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
@@ -28,25 +31,18 @@ import org.jetbrains.annotations.Nullable;
 
 public class PalmLeavesBakedModel extends BaseBakedModel
 {
-    public static List<PalmLeavesBakedModel> INSTANCES = new ArrayList<>();
-
     protected final BlockModel blockModel;
 
-    ResourceLocation frondsResLoc;
-    TextureAtlasSprite frondsTexture;
+    private final TextureAtlasSprite frondsTexture;
 
-    private final BakedModel[] bakedFronds = new BakedModel[8]; // 8 = Number of surrounding blocks
+    private final BakedModel[] bakedFronds;
 
-    public PalmLeavesBakedModel(ResourceLocation modelResLoc, ResourceLocation frondsResLoc)
+    public PalmLeavesBakedModel(ResourceLocation modelResLoc, ResourceLocation frondsResLoc, Function<Material, TextureAtlasSprite> spriteGetter)
     {
         this.blockModel = new BlockModel(null, new ArrayList<>(), new HashMap<>(), false, BlockModel.GuiLight.FRONT, ItemTransforms.NO_TRANSFORMS, new ArrayList<>());
-        this.frondsResLoc = frondsResLoc;
-        INSTANCES.add(this);
-    }
+        this.bakedFronds = new BakedModel[8];
 
-    public void setupModels()
-    {
-        frondsTexture = ModelUtils.getTexture(frondsResLoc);
+        frondsTexture = spriteGetter.apply(new Material(TextureAtlas.LOCATION_BLOCKS, frondsResLoc));
 
         for (CoordUtils.Surround surr : CoordUtils.Surround.values())
         {

--- a/src/main/java/org/labellum/mc/dttfc/client/PalmLeavesModelGeometry.java
+++ b/src/main/java/org/labellum/mc/dttfc/client/PalmLeavesModelGeometry.java
@@ -25,6 +25,6 @@ public class PalmLeavesModelGeometry implements IUnbakedGeometry<PalmLeavesModel
     @Override
     public BakedModel bake(IGeometryBakingContext context, ModelBaker baker, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ItemOverrides overrides, ResourceLocation modelLocation)
     {
-        return new PalmLeavesBakedModel(modelLocation, frondsResLoc);
+        return new PalmLeavesBakedModel(modelLocation, frondsResLoc, spriteGetter);
     }
 }


### PR DESCRIPTION
This PR fixes compatibility with ModernFix's dynamic resources optimization and also fixes a memory leak when reloading resources (e.g. by changing resource packs or pressing F3+T). It removes the global `PalmLeavesBakedModel.INSTANCES` list and bakes the frond models in the parent model's constructor instead. In order to have access to the necessary sprites during baking (before the texture atlas is available in the normal way), the sprite getter is passed through from the model geometry class.

Removal of `INSTANCES` is necessary for dynamic resources compatibility as the previous code assumed all models are loaded during startup, which is not the case with this optimization enabled. Moreover, since `INSTANCES` was never cleared, many redundant instances of baked models would accumulate in the list over time.